### PR TITLE
Deploy to aws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,5 +128,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# cache file
-*.sqlite
+# deployment file
+*.serverless

--- a/Pipfile
+++ b/Pipfile
@@ -6,15 +6,17 @@ name = "pypi"
 [packages]
 slack-bolt = "*"
 requests = "*"
-requests-cache = "*"
+boto3 = "*"
+zappa = "*"
+troposphere = "==2.7.0"
+slack-sdk = "*"
 aiohttp = "*"
-asyncio = "*"
+cachetools = "*"
 
 [dev-packages]
 autopep8 = "*"
 pytest = "*"
-pytest-asyncio = "*"
 faker = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -7,10 +7,7 @@ name = "pypi"
 slack-bolt = "*"
 requests = "*"
 boto3 = "*"
-zappa = "*"
-troposphere = "==2.7.0"
 slack-sdk = "*"
-aiohttp = "*"
 cachetools = "*"
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,6 @@ name = "pypi"
 [packages]
 slack-bolt = "*"
 requests = "*"
-boto3 = "*"
 slack-sdk = "*"
 cachetools = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8c7edbdf16e4dcdc06e0926b9f6adf2608d95082426a333ef9694a01b444f83c"
+            "sha256": "3ab25e71df6b2b60131c7d7dfed96bc37fbbfbf5267273d60efb376cc6f43b50"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -59,6 +59,13 @@
             "index": "pypi",
             "version": "==3.7.4.post0"
         },
+        "argcomplete": {
+            "hashes": [
+                "sha256:291f0beca7fd49ce285d2f10e4c1c77e9460cf823eef2de54df0c0fec88b0d81",
+                "sha256:2c7dbffd8c045ea534921e63b0be6fe65e88599990d8dc408ac8c542b72a5445"
+            ],
+            "version": "==1.12.3"
+        },
         "async-timeout": {
             "hashes": [
                 "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
@@ -66,16 +73,6 @@
             ],
             "markers": "python_full_version >= '3.5.3'",
             "version": "==3.0.1"
-        },
-        "asyncio": {
-            "hashes": [
-                "sha256:83360ff8bc97980e4ff25c964c7bd3923d333d177aa4f7fb736b019f26c7cb41",
-                "sha256:b62c9157d36187eca799c378e572c969f0da87cd5fc42ca372d92cdb06e7e1de",
-                "sha256:c46a87b48213d7464f22d9a497b9eef8c1928b68320a2fa94240f969f6fec08c",
-                "sha256:c4d18b22701821de07bd6aea8b53d21449ec0ec5680645e5317062ea21817d2d"
-            ],
-            "index": "pypi",
-            "version": "==3.4.3"
         },
         "attrs": {
             "hashes": [
@@ -85,12 +82,42 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
         },
+        "boto3": {
+            "hashes": [
+                "sha256:4c1638a31da2948180bf66fac2971e0350b6b04c1b90910cd15247c77209ccaf",
+                "sha256:ca675c724fa0fe05e992a7146cc5e1a3b3262c4323c83c7a8fcc69f9e5e47f8b"
+            ],
+            "index": "pypi",
+            "version": "==1.18.11"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:601f820ed340a85ed62d91b4eaeb768b9ff0529add75a074592fb7c51db7bd00",
+                "sha256:b5e9128a259fc0fe5a8c2b717f5d7e8a1321321981b5d5679939e12d4142c0f3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.21.11"
+        },
+        "cachetools": {
+            "hashes": [
+                "sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001",
+                "sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff"
+            ],
+            "index": "pypi",
+            "version": "==4.2.2"
+        },
         "certifi": {
             "hashes": [
                 "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
                 "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
             ],
             "version": "==2021.5.30"
+        },
+        "cfn-flip": {
+            "hashes": [
+                "sha256:2bed32a1f4dca26dc64178d52511fd4ef778b5ccbcf32559cac884ace75bde6a"
+            ],
+            "version": "==1.2.3"
         },
         "chardet": {
             "hashes": [
@@ -108,6 +135,42 @@
             "markers": "python_version >= '3'",
             "version": "==2.0.4"
         },
+        "click": {
+            "hashes": [
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.1"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+            ],
+            "markers": "platform_system == 'Windows' and platform_system == 'Windows'",
+            "version": "==0.4.4"
+        },
+        "durationpy": {
+            "hashes": [
+                "sha256:5ef9416b527b50d722f34655becfb75e49228eb82f87b855ed1911b3314b5408"
+            ],
+            "version": "==0.5"
+        },
+        "future": {
+            "hashes": [
+                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.18.2"
+        },
+        "hjson": {
+            "hashes": [
+                "sha256:2838fd7200e5839ea4516ece953f3a19892c41089f0d933ba3f68e596aacfcd5",
+                "sha256:5546438bf4e1b52bc964c6a47c4ed10fa5fba8a1b264e22efa893e333baad2db"
+            ],
+            "version": "==3.0.2"
+        },
         "idna": {
             "hashes": [
                 "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
@@ -116,13 +179,20 @@
             "markers": "python_version >= '3'",
             "version": "==3.2"
         },
-        "itsdangerous": {
+        "jmespath": {
             "hashes": [
-                "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c",
-                "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
-            "version": "==2.0.1"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.0"
+        },
+        "kappa": {
+            "hashes": [
+                "sha256:4b5b372872f25d619e427e04282551048dc975a107385b076b3ffc6406a15833",
+                "sha256:4d6b7b3accce4a0aaaac92b36237a6304f0f2fffbbe3caea3f7c9f52d12c9989"
+            ],
+            "version": "==0.6.0"
         },
         "multidict": {
             "hashes": [
@@ -164,8 +234,45 @@
                 "sha256:f21756997ad8ef815d8ef3d34edd98804ab5ea337feedcd62fb52d22bf531281",
                 "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==5.1.0"
+        },
+        "pep517": {
+            "hashes": [
+                "sha256:3fa6b85b9def7ba4de99fb7f96fe3f02e2d630df8aa2720a5cf3b183f087a738",
+                "sha256:e1ba5dffa3a131387979a68ff3e391ac7d645be409216b961bc2efe6468ab0b2"
+            ],
+            "version": "==0.11.0"
+        },
+        "pip-tools": {
+            "hashes": [
+                "sha256:77727ef7457d1865e61fe34c2b1439f9b971b570cc232616a22ce82ab89d357d",
+                "sha256:9ed38c73da4993e531694ea151f77048b4dbf2ba7b94c4a569daa39568cc6564"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==6.2.0"
+        },
+        "placebo": {
+            "hashes": [
+                "sha256:03157f8527bbc2965b71b88f4a139ef8038618b346787f20d63e3c5da541b047"
+            ],
+            "version": "==0.9.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
+        },
+        "python-slugify": {
+            "hashes": [
+                "sha256:6d8c5df75cd4a7c3a2d21e257633de53f52ab0265cd2d1dc62a730e8194a7380",
+                "sha256:f13383a0b9fcbe649a1892b9c8eb4f8eab1d6d84b84bb7a624317afa98159cab"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==5.0.2"
         },
         "pyyaml": {
             "hashes": [
@@ -210,13 +317,13 @@
             "index": "pypi",
             "version": "==2.26.0"
         },
-        "requests-cache": {
+        "s3transfer": {
             "hashes": [
-                "sha256:0be6dc60158a4ffa89935c9d652a121ddf758f467c43b34b752a2b8df2217a9d",
-                "sha256:b6ae192defa2a5f45caf48f5f4f980fd6fe6f5f348470079224d8a5cd3858fee"
+                "sha256:50ed823e1dc5868ad40c8dc92072f757aa0e653a192845c94a3b676f4a62da4c",
+                "sha256:9c1dc369814391a6bda20ebbf4b70a0f34630592c9aa520856bf384916af2803"
             ],
-            "index": "pypi",
-            "version": "==0.7.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==0.5.0"
         },
         "six": {
             "hashes": [
@@ -239,8 +346,46 @@
                 "sha256:802dd4297bde5c5092e24e268f8b3dcbd89cd100e8d68b94ad29f0269a67c86d",
                 "sha256:cb90ce362b2497169cba5488c9ac0f6bc0d7941a3d6c4e4bee469c1cda391f39"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "index": "pypi",
             "version": "==3.8.0"
+        },
+        "text-unidecode": {
+            "hashes": [
+                "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8",
+                "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"
+            ],
+            "version": "==1.3"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:056f0376bf5a6b182c513f9582c1e5b0487265eb6c48842b69aa9ca1cd5f640a",
+                "sha256:d60e681734099207a6add7a10326bc2ddd1fdc36c1b0f547d00ef73ac63739c2"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.2.0"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:3642d483b558eec80d3c831e23953582c34d7e4540db86d9e5ed9dad238dabc6",
+                "sha256:706dea48ee05ba16e936ee91cb3791cd2ea6da348a0e50b46863ff4363ff4340"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==4.62.0"
+        },
+        "troposphere": {
+            "hashes": [
+                "sha256:b0ab144b989e1e1c4698e601008bd5f7fbabd0629b4588cb57d3583f8aa6edc9"
+            ],
+            "index": "pypi",
+            "version": "==2.7.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -250,21 +395,35 @@
             ],
             "version": "==3.10.0.0"
         },
-        "url-normalize": {
-            "hashes": [
-                "sha256:d23d3a070ac52a67b83a1c59a0e68f8608d1cd538783b401bc9de2c0fac999b2",
-                "sha256:ec3c301f04e5bb676d333a7fa162fa977ad2ca04b7e652bfc9fac4e405728eed"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.4.3"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
                 "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.6"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:1e0dedc2acb1f46827daa2e399c1485c8fa17c0d8e70b6b875b4e7f54bf408d2",
+                "sha256:b353856d37dec59d6511359f97f6a4b2468442e454bd1c98298ddce53cac1f04"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.16.1"
+        },
+        "wheel": {
+            "hashes": [
+                "sha256:78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e",
+                "sha256:e11eefd162658ea59a60a0f6c7d493a7190ea4b9a85e335b33489d9f17e0245e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.36.2"
+        },
+        "wsgi-request-logger": {
+            "hashes": [
+                "sha256:445d7ec52799562f812006394d0b4a7064b37084c6ea6bd74ea7a2136c97ed83"
+            ],
+            "version": "==0.4.6"
         },
         "yarl": {
             "hashes": [
@@ -306,8 +465,16 @@
                 "sha256:f0b059678fd549c66b89bed03efcabb009075bd131c248ecdf087bdb6faba24a",
                 "sha256:fcbb48a93e8699eae920f8d92f7160c03567b421bc17362a9ffbbd706a816f71"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==1.6.3"
+        },
+        "zappa": {
+            "hashes": [
+                "sha256:46a0afc1218de17bf713a8f4cfcb4dde2ba0466d18088918b9d2bc22ec6f9434",
+                "sha256:a3623197a1dd30faa028f62fda1b7ba5dcbb643bc6ac43ad4cffdfd89a3b85c8"
+            ],
+            "index": "pypi",
+            "version": "==0.53.0"
         }
     },
     "develop": {
@@ -340,7 +507,7 @@
                 "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
                 "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
             ],
-            "markers": "sys_platform == 'win32'",
+            "markers": "platform_system == 'Windows' and platform_system == 'Windows'",
             "version": "==0.4.4"
         },
         "faker": {
@@ -405,14 +572,6 @@
             ],
             "index": "pypi",
             "version": "==6.2.4"
-        },
-        "pytest-asyncio": {
-            "hashes": [
-                "sha256:2564ceb9612bbd560d19ca4b41347b54e7835c2f792c504f698e05395ed63f6f",
-                "sha256:3042bcdf1c5d978f6b74d96a151c4cfb9dcece65006198389ccd7e6c60eb1eea"
-            ],
-            "index": "pypi",
-            "version": "==0.15.1"
         },
         "python-dateutil": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ cd src
 pipenv install --dev
 
 # Run tests
-pipenv run pytest
+pipenv run python -m pytest
 ```
 ## Approach
 I started by reading through the [Getting Started Guide for Bolt][7] as well as a couple other getting started resources. From there I laid out a general plan of what I was planning to accomplish.
@@ -86,7 +86,7 @@ I started by reading through the [Getting Started Guide for Bolt][7] as well as 
 1. Create a hello world slack app
 2. Figure out the general workflow of how to send a message
 3. Connect to the MovieDB API and return actual data
-4. Modify the UI elements to meet the requirements
+4. Modify the UI elements to meet the requirements with [Block Kits][10]
 5. Create unit tests
 6. Add better error handling and logging
 7. Create a good readme
@@ -121,3 +121,8 @@ Please make sure to update tests as appropriate.
 [7]: https://slack.dev/bolt-python/tutorial/getting-started
 [8]: https://github.com/slackapi/bolt-python/tree/main/examples/aws_lambda
 [9]: https://choosealicense.com/licenses/mit/
+[10]: https://app.slack.com/block-kit-builder/
+
+https://github.com/slackapi/bolt-examples-aws-re-invent-2020/tree/main/api-gateway-lambda/python
+https://github.com/zappa/Zappa
+https://chatbotslife.com/developing-your-own-bot-for-slack-and-serverless-deploy-a49136f68b7a

--- a/README.md
+++ b/README.md
@@ -57,6 +57,40 @@ For example: http://ad646ed78782.ngrok.io/slack/events
 Update your [Interactivity & Shortcuts][4] Request URL and Options Load URL with your ngrok hostname followed by /slack/events
 For example: http://ad646ed78782.ngrok.io/slack/events
 
+## Deploying to AWS Lambda
+
+### 1. Setup environment
+```zsh
+# Change into the project directory
+cd src
+
+# Output deterministic requirements
+pipenv lock -r > requirements.txt
+
+# Install to target directory
+pip install -r requirements.txt -t lib
+```
+
+### 2. Deploy to AWS
+If you have not already please [configure the AWS CLI][11]
+If you have not already please install node.js to take advantage of npm
+
+serverless is a tool that packages applications to be deployed on various serverless environments. In our case AWS Lambda/API Gateway
+```zsh
+# Deploy
+npx serverless deployment
+```
+
+### 3. Add Environment Variables
+Navigate to the AWS Lambda Services and find your lambda. Go to the configuration tab in the middle tab collection and add your 3 [environment variables](#1-setup-environment-variables)
+
+### 4. Configure your slack app
+Update your [Event Subscriptions][1] Request URL with your API endpoint https://z5xasw5ss9.execute-api.us-east-2.amazonaws.com/dev/slack/events
+For example: http://ad646ed78782.ngrok.io/slack/events
+
+Update your [Interactivity & Shortcuts][4] Request URL and Options Load URL with your API endpoint https://z5xasw5ss9.execute-api.us-east-2.amazonaws.com/dev/slack/events
+For example: http://ad646ed78782.ngrok.io/slack/events
+
 ## File/Folder Structure
 ```text
 .
@@ -65,11 +99,14 @@ For example: http://ad646ed78782.ngrok.io/slack/events
    └── api.py: Handles the external calls to the Movie Database
    └── utils.py: Useful methods for cleaner looking code
    └── conftest.py: Used to define the test root path
+   └── serverless.yml: Config file for serverless packaging and deployment
    └── tests: All programmatic tests
    └── views: Contains the json files of the Slack Block Kits
 ```
 
 ## Testing
+You will have to export keys in [setup environment variables](#1-setup-environment-variables) so that app.py has something to pull in.
+
 ```zsh
 # Navigate into the src directory
 cd src
@@ -90,6 +127,7 @@ I started by reading through the [Getting Started Guide for Bolt][7] as well as 
 5. Create unit tests
 6. Add better error handling and logging
 7. Create a good readme
+8. Deploy to cloud hosted environment manually([aws lambda][8])
 
 I knew I could tackle this project a little differently, as I would be the only developer working on this code, I could be messier and cleanup at the end to save myself time.
 Time would be the biggest factor and I wanted to prioritize the requirements spelled out vs what I assumed was needed, preferring completeness/thoroughness over shiney things.
@@ -99,10 +137,9 @@ I would have likely done testing, error handling, and logging with smaller items
 ## Roadmap
 As I finish items on my roadmap I will move them to the approach section. This roadmap gives me an ordered list of my top priorities as well as any upcoming changes I would like to make.
 
-8. Deploy to cloud hosted environment manually([aws lambda][8])
-8. Script out deployment
-8. Create infrastructure as code (aws_cdk)
-8. Create CI/CD pipeline (github actions)
+1. Script out deployment
+2. Create infrastructure as code (aws_cdk)
+3. Create CI/CD pipeline (github actions)
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
@@ -119,10 +156,7 @@ Please make sure to update tests as appropriate.
 [5]: https://api.slack.com/apps/A029AU6BDD4/general?
 [6]: https://developers.themoviedb.org/3/getting-started/introduction
 [7]: https://slack.dev/bolt-python/tutorial/getting-started
-[8]: https://github.com/slackapi/bolt-python/tree/main/examples/aws_lambda
+[8]: https://github.com/slackapi/bolt-examples-aws-re-invent-2020/tree/main/api-gateway-lambda/python
 [9]: https://choosealicense.com/licenses/mit/
 [10]: https://app.slack.com/block-kit-builder/
-
-https://github.com/slackapi/bolt-examples-aws-re-invent-2020/tree/main/api-gateway-lambda/python
-https://github.com/zappa/Zappa
-https://chatbotslife.com/developing-your-own-bot-for-slack-and-serverless-deploy-a49136f68b7a
+[11]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html

--- a/src/api.py
+++ b/src/api.py
@@ -1,16 +1,18 @@
+import sys
+sys.path.insert(1, "lib/")
+
 import os
 import requests
-import requests_cache
+import cachetools.func
 import json
 import logging
 
 
 class MovieApis:
     api_key = os.environ.get("API_KEY")
-    requests_cache.install_cache(
-        "movie_cache", backend="sqlite", expire_after=360)
 
     @staticmethod
+    @cachetools.func.ttl_cache(maxsize=20, ttl=300)
     def get_movie_details(movie_id: str, region: str) -> dict:
         params = {
             "api_key": MovieApis.api_key,
@@ -28,6 +30,7 @@ class MovieApis:
         return data
 
     @staticmethod
+    @cachetools.func.ttl_cache(maxsize=5, ttl=300)
     def get_list_of_movies(pages: int) -> list:
         movie_list = []
         params = {

--- a/src/app.py
+++ b/src/app.py
@@ -84,6 +84,6 @@ def handler(event, context):
     slack_handler = SlackRequestHandler(app=app)
     return slack_handler.handle(event, context)
 
-# # Start your app
+# # For Local testing
 # if __name__ == "__main__":
 #     app.start(port=int(os.environ.get("PORT", 3000)))

--- a/src/app.py
+++ b/src/app.py
@@ -4,6 +4,7 @@ import logging
 from typing import Callable
 from slack_bolt.async_app import AsyncApp
 from slack_sdk import WebClient
+from slack_bolt.adapter.aws_lambda import SlackRequestHandler
 from api import MovieApis
 import utils
 
@@ -11,7 +12,8 @@ import utils
 logging.basicConfig(filename='application.log', level=logging.DEBUG)
 app = AsyncApp(
     token=os.environ.get("SLACK_BOT_TOKEN"),
-    signing_secret=os.environ.get("SLACK_SIGNING_SECRET")
+    signing_secret=os.environ.get("SLACK_SIGNING_SECRET",
+                                  process_before_response=True)
 )
 
 
@@ -74,6 +76,9 @@ async def handle_action(ack: Callable) -> None:
     await ack()
 
 
-# Start your app
-if __name__ == "__main__":
-    app.start(port=int(os.environ.get("PORT", 3000)))
+# # Start your app
+# if __name__ == "__main__":
+#     app.start(port=int(os.environ.get("PORT", 3000)))
+def handler(event, context):
+    slack_handler = SlackRequestHandler(app=app)
+    return slack_handler.handle(event, context)

--- a/src/app.py
+++ b/src/app.py
@@ -1,40 +1,44 @@
-import os
-import json
-import logging
-from typing import Callable
-from slack_bolt.async_app import AsyncApp
-from slack_sdk import WebClient
-from slack_bolt.adapter.aws_lambda import SlackRequestHandler
-from api import MovieApis
+import sys
+sys.path.insert(1, "lib/")
+
 import utils
+from api import MovieApis
+from slack_bolt.adapter.aws_lambda import SlackRequestHandler
+from slack_sdk import WebClient
+from slack_bolt import App
+from typing import Callable
+import logging
+import json
+import os
+
+
 
 # Initializes app
-logging.basicConfig(filename='application.log', level=logging.DEBUG)
-app = AsyncApp(
-    token=os.environ.get("SLACK_BOT_TOKEN"),
-    signing_secret=os.environ.get("SLACK_SIGNING_SECRET",
-                                  process_before_response=True)
-)
+SlackRequestHandler.clear_all_log_handlers()
+logging.basicConfig(level=logging.DEBUG)
+app = App(token=os.environ.get("SLACK_BOT_TOKEN"),
+          signing_secret=os.environ.get("SLACK_SIGNING_SECRET"),
+          process_before_response=True)
 
 
 @app.event("app_home_opened")
-async def update_home_tab(client: WebClient, event: dict, logger: logging.Logger) -> None:
+def update_home_tab(client: WebClient, event: dict, logger: logging.Logger) -> None:
     try:
         with open('./views/home.json') as f:
             home = json.load(f)
-        await client.views_publish(user_id=event["user"], view=home)
+        client.views_publish(user_id=event["user"], view=home)
 
     except Exception as e:
         logger.error(f"Error publishing home tab: {e}")
 
 
 @app.action("button_click")
-async def action_button_click(ack: Callable, client: WebClient, body: dict, logger: logging.Logger) -> None:
+def action_button_click(ack: Callable, client: WebClient, body: dict, logger: logging.Logger) -> None:
     try:
-        await ack()
+        ack()
         with open('./views/movie_modal.json') as f:
             movie_modal = json.load(f)
-        await client.views_open(trigger_id=body["trigger_id"], view=movie_modal)
+        client.views_open(trigger_id=body["trigger_id"], view=movie_modal)
 
     except Exception as e:
         logger.error(f"Error loading movie search window: {e}")
@@ -42,9 +46,9 @@ async def action_button_click(ack: Callable, client: WebClient, body: dict, logg
 
 # https://slack.dev/bolt-python/concepts#view_submissions
 @app.view("movie_modal")
-async def handle_movie_submission(ack: Callable, body: dict, client: WebClient, logger: logging.Logger) -> None:
+def handle_movie_submission(ack: Callable, body: dict, client: WebClient, logger: logging.Logger) -> None:
 
-    await ack()
+    ack()
     user = body["user"]["id"]
     values = body["view"]["state"]["values"]
     movie_id = values["movie_selection"]["movie_search"]["selected_option"]["value"]
@@ -56,29 +60,30 @@ async def handle_movie_submission(ack: Callable, body: dict, client: WebClient, 
         data["original_title"], data["release_date"], data["overview"], poster_url)
     try:
         payload = "Movie info sent"
-        await client.chat_postMessage(blocks=movie_message,
-                                      channel=user, text=payload)
+        client.chat_postMessage(blocks=movie_message,
+                                channel=user, text=payload)
     except Exception as e:
         payload = "💩 something went wrong. Try again!"
         logger.error("Couldn't send movie details to user")
-        await client.chat_postMessage(text=payload, channel=user)
+        client.chat_postMessage(text=payload, channel=user)
 
 
 @app.options("movie_search")
-async def show_list_of_movies(ack: Callable) -> None:
+def show_list_of_movies(ack: Callable) -> None:
     # BUG: typeahead doesnt seem to be filtering on my external list
     movie_list = MovieApis.get_list_of_movies(5)
-    await ack(options=movie_list)
+    ack(options=movie_list)
 
 
 @app.action("movie_search")
-async def handle_action(ack: Callable) -> None:
-    await ack()
+def handle_action(ack: Callable) -> None:
+    ack()
 
+
+def handler(event, context):
+    slack_handler = SlackRequestHandler(app=app)
+    return slack_handler.handle(event, context)
 
 # # Start your app
 # if __name__ == "__main__":
 #     app.start(port=int(os.environ.get("PORT", 3000)))
-def handler(event, context):
-    slack_handler = SlackRequestHandler(app=app)
-    return slack_handler.handle(event, context)

--- a/src/serverless.yml
+++ b/src/serverless.yml
@@ -1,0 +1,39 @@
+service: slack-movie-app
+
+provider:
+  name: aws
+  runtime: python3.8
+  stage: ${opt:stage, 'dev'}
+  # https://www.serverless.com/framework/docs/deprecations/#AWS_API_GATEWAY_NAME_STARTING_WITH_SERVICE
+  apiGateway:
+    shouldStartNameWithService: true
+  region: us-east-2
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - lambda:InvokeFunction
+        - lambda:InvokeAsync
+      Resource: "*"
+  environment:
+    SERVERLESS_STAGE: ${opt:stage, 'dev'}
+
+# you can add packaging information here
+package:
+  include:
+    - app.py
+    - api.py
+    - utils.py
+    - views/*
+    - lib/*
+  exclude:
+    - README.md
+    - tests/*
+    - .serverless
+
+functions:
+  api:
+    handler: app.handler
+    events:
+      - http:
+          path: slack/events
+          method: post

--- a/src/tests/unit/test_app.py
+++ b/src/tests/unit/test_app.py
@@ -1,53 +1,53 @@
 from logging import Logger
 import os
-from unittest import IsolatedAsyncioTestCase
-from unittest.mock import patch, AsyncMock
+from unittest.case import TestCase
+from unittest.mock import patch, MagicMock
 from faker import Faker
 import app
 
 
-class TestApp(IsolatedAsyncioTestCase):
+class TestApp(TestCase):
     def setUp(self) -> None:
         patch("os.environ.get").start()
         self.fake = Faker()
         self.addCleanup(patch.stopall)
-        self.client = AsyncMock()
-        self.logger = AsyncMock(spec=Logger)
-        self.ack = AsyncMock()
-        self.event = AsyncMock()
-        self.body = AsyncMock()
+        self.client = MagicMock()
+        self.logger = MagicMock(spec=Logger)
+        self.ack = MagicMock()
+        self.event = MagicMock()
+        self.body = MagicMock()
         return super().setUp()
 
-    async def test_update_home_tab_publishes_view(self):
+    def test_update_home_tab_publishes_view(self):
         expected_home = self.fake.word()
         mock_home = patch("json.load").start()
         mock_home.return_value = expected_home
 
-        await app.update_home_tab(self.client, self.event, self.logger)
+        app.update_home_tab(self.client, self.event, self.logger)
 
         self.client.views_publish.assert_called_once_with(
             user_id=self.event["user"], view=expected_home)
 
-    async def test_action_button_click_opens_view(self):
+    def test_action_button_click_opens_view(self):
         expected_movie_modal = self.fake.word()
         mock_movie_modal = patch("json.load").start()
         mock_movie_modal.return_value = expected_movie_modal
 
-        await app.action_button_click(self.ack, self.client, self.body, self.logger)
+        app.action_button_click(self.ack, self.client, self.body, self.logger)
 
         self.client.views_open.assert_called_once_with(
             trigger_id=self.body["trigger_id"], view=expected_movie_modal)
 
-    async def test_show_list_of_movies_calls_movie_list(self):
+    def test_show_list_of_movies_calls_movie_list(self):
         mock_get_list_of_movies = patch(
             "api.MovieApis.get_list_of_movies").start()
         pages_of_movies = 5
 
-        await app.show_list_of_movies(self.ack)
+        app.show_list_of_movies(self.ack)
 
         mock_get_list_of_movies.assert_called_once_with(pages_of_movies)
 
-    async def test_handle_movie_submission_calls_movie_details_with_params(self):
+    def test_handle_movie_submission_calls_movie_details_with_params(self):
         mock_get_movie_details = patch(
             "api.MovieApis.get_movie_details").start()
         patch("utils.convert_date").start()
@@ -57,13 +57,13 @@ class TestApp(IsolatedAsyncioTestCase):
         self.body = {"view": {"state": {"values": {"movie_selection": {"movie_search": {
             "selected_option": {"value": expected_movie_id}}}}}}, "user": {"id": mock_user}}
 
-        await app.handle_movie_submission(
+        app.handle_movie_submission(
             self.ack, self.body, self.client, self.logger)
 
         mock_get_movie_details.assert_called_once_with(
             expected_movie_id, expected_region)
 
-    async def test_handle_movie_submission_calls_convert_date_with_release_date(self):
+    def test_handle_movie_submission_calls_convert_date_with_release_date(self):
         mock_get_movie_details = patch(
             "api.MovieApis.get_movie_details").start()
         expected_date = self.fake.date()
@@ -74,12 +74,12 @@ class TestApp(IsolatedAsyncioTestCase):
         mock_get_movie_details.return_value = expected_details
         mock_convert_date = patch("utils.convert_date").start()
 
-        await app.handle_movie_submission(
+        app.handle_movie_submission(
             self.ack, self.body, self.client, self.logger)
 
         mock_convert_date.assert_called_once_with(expected_date)
 
-    async def test_handle_movie_submission_posts_message(self):
+    def test_handle_movie_submission_posts_message(self):
         patch("api.MovieApis.get_movie_details").start()
         expected_blocks = self.fake.word()
         mock_create_message_blocks = patch(
@@ -87,24 +87,24 @@ class TestApp(IsolatedAsyncioTestCase):
         mock_create_message_blocks.return_value = expected_blocks
         expected_payload = "Movie info sent"
 
-        await app.handle_movie_submission(
+        app.handle_movie_submission(
             self.ack, self.body, self.client, self.logger)
 
         self.client.chat_postMessage.assert_called_once_with(
             blocks=expected_blocks, channel=self.body["expected_user"]["expected_id"], text=expected_payload)
 
-    async def test_show_list_of_movies_calls_ack_with_options(self):
+    def test_show_list_of_movies_calls_ack_with_options(self):
         expected_movie_list = self.fake.word()
         mock_get_list_of_movies = patch(
             "api.MovieApis.get_list_of_movies").start()
         mock_get_list_of_movies.return_value = expected_movie_list
 
-        await app.show_list_of_movies(self.ack)
+        app.show_list_of_movies(self.ack)
 
         self.ack.assert_called_once_with(options=expected_movie_list)
 
-    async def test_handle_action_calls_ack(self):
+    def test_handle_action_calls_ack(self):
 
-        await app.handle_action(self.ack)
+        app.handle_action(self.ack)
 
         self.ack.assert_called_once()

--- a/src/utils.py
+++ b/src/utils.py
@@ -39,6 +39,6 @@ def create_message_blocks(title: str, date: str, overview: str, poster_url: str)
     return movie_message
 
 
-# Start your app
-if __name__ == "__main__":
-    convert_date()
+# # Start your app
+# if __name__ == "__main__":
+#     convert_date()


### PR DESCRIPTION
Followed multiple docs, the most helpful was: https://github.com/slackapi/bolt-examples-aws-re-invent-2020/tree/main/api-gateway-lambda/python

I spent too much time trying to get my AsyncApp to work, I checked: https://github.com/slackapi/bolt-python/blob/main/slack_bolt/adapter/aws_lambda/handler.py

I realized that AsyncApp was not what the handler was expecting, once I switched it, it worked no problem. Had to update the tests again.

requests_cache stores on a file system which is not allowed in lambda except for tmp, which you cannot force it to write there. So I switched caching, I think I prefer cachetools better though.